### PR TITLE
CAMSERV-120 - Allow "extra" JSON fields on Log Records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 .*.sw?
 tags
+test.log
+timber_test.log

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/cocoonlife/timber
+
+go 1.21.9
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/cocoonlife/timber
 
-go 1.21.9
+go 1.21
+
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -16,6 +16,6 @@ func (f *JSONFormatter) Format(rec *LogRecord) string {
 	if msg, err := json.Marshal(rec); err == nil {
 		return string(msg)
 	} else {
-		return fmt.Sprintf("JSON Marshal Fail:%s - %s", err.Error(), rec)
+		return fmt.Sprintf("JSON Marshal Fail:%s - %v", err.Error(), rec)
 	}
 }

--- a/timber.go
+++ b/timber.go
@@ -458,7 +458,16 @@ func (t *Timber) SetFormatter(index int, formatter LogFormatter) {
 }
 
 // Logger interface
-func (t *Timber) prepareAndSend(lvl Level, extra map[string]string, msg string, depth int) {
+func (t *Timber) prepareAndSend(lvl Level, msg string, depth int) {
+	var emptyExtra map[string]string
+	t.doPrepareAndSend(lvl, emptyExtra, msg, depth)
+}
+
+func (t *Timber) prepareAndSendEx(lvl Level, extra map[string]string, msg string, depth int) {
+	t.doPrepareAndSend(lvl, extra, msg, depth)
+}
+
+func (t *Timber) doPrepareAndSend(lvl Level, extra map[string]string, msg string, depth int) {
 	select {
 	case <-t.blackHole:
 		// the blackHole always blocks until we close
@@ -526,166 +535,164 @@ func (t *Timber) prepare(lvl Level, extra map[string]string, msg string, depth i
 	}
 }
 
-var emptyExtra map[string]string
-
 // This function allows a Timber instance to be used in the standard library
 // log.SetOutput().  It is not a general Writer interface and assumes one
 // message per call to Write. All messages are send at level INFO
 func (t *Timber) Write(p []byte) (n int, err error) {
-	t.prepareAndSend(INFO, emptyExtra, string(bytes.TrimSpace(p)), 4)
+	t.prepareAndSend(INFO, string(bytes.TrimSpace(p)), 4)
 	return len(p), nil
 }
 
 func (t *Timber) Finest(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINEST, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(FINEST, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Fine(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINE, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(FINE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Debug(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(DEBUG, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Trace(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(TRACE, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(TRACE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Info(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(INFO, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(INFO, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Warn(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(WARNING, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(WARNING, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Error(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(ERROR, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(ERROR, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Critical(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Log(lvl Level, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(lvl, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(lvl, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 
 // The govet printf family of warnings triggers on Erorr() and similar containing format strings
 // Add more golike Foof() formatters. Other methods should be considered deprecated
 func (t *Timber) Finestf(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINEST, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(FINEST, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Finef(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINE, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(FINE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Debugf(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(DEBUG, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Tracef(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(TRACE, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(TRACE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Infof(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(INFO, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(INFO, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Warnf(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(WARNING, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(WARNING, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Errorf(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(ERROR, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(ERROR, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Criticalf(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Logf(lvl Level, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(lvl, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(lvl, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 
 // Print won't work well with a pattern_logger because it explicitly adds
 // its own \n; so you'd have to write your own formatter to remove it
 func (t *Timber) Print(v ...interface{}) {
-	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprint(v...), t.FileDepth)
+	t.prepareAndSend(DEBUG, fmt.Sprint(v...), t.FileDepth)
 }
 func (t *Timber) Printf(format string, v ...interface{}) {
-	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprintf(format, v...), t.FileDepth)
+	t.prepareAndSend(DEBUG, fmt.Sprintf(format, v...), t.FileDepth)
 }
 
 // Println won't work well either with a pattern_logger because it explicitly adds
 // its own \n; so you'd have to write your own formatter to not have 2 \n's
 func (t *Timber) Println(v ...interface{}) {
-	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprintln(v...), t.FileDepth)
+	t.prepareAndSend(DEBUG, fmt.Sprintln(v...), t.FileDepth)
 }
 func (t *Timber) Panic(v ...interface{}) {
 	msg := fmt.Sprint(v...)
-	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
 	panic(msg)
 }
 func (t *Timber) Panicf(format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
-	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
 	panic(msg)
 }
 func (t *Timber) Panicln(v ...interface{}) {
 	msg := fmt.Sprintln(v...)
-	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
 	panic(msg)
 }
 func (t *Timber) Fatal(v ...interface{}) {
 	msg := fmt.Sprint(v...)
-	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
 	t.Close()
 	os.Exit(1)
 }
 func (t *Timber) Fatalf(format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
-	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
 	t.Close()
 	os.Exit(1)
 }
 func (t *Timber) Fatalln(v ...interface{}) {
 	msg := fmt.Sprintln(v...)
-	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
 	t.Close()
 	os.Exit(1)
 }
 
 func (t *Timber) FinestEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINEST, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSendEx(FINEST, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) FineEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINE, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSendEx(FINE, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) DebugEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(DEBUG, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSendEx(DEBUG, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) TraceEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(TRACE, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSendEx(TRACE, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) InfoEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(INFO, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSendEx(INFO, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) WarnEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(WARNING, extra, msg, t.FileDepth)
+	t.prepareAndSendEx(WARNING, extra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) ErrorEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(ERROR, extra, msg, t.FileDepth)
+	t.prepareAndSendEx(ERROR, extra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) CriticalEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(CRITICAL, extra, msg, t.FileDepth)
+	t.prepareAndSendEx(CRITICAL, extra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) LogEx(extra map[string]string, lvl Level, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(lvl, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSendEx(lvl, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 
 //

--- a/timber.go
+++ b/timber.go
@@ -728,6 +728,34 @@ func Fatal(v ...interface{})                 { Global.Fatal(v...) }
 func Fatalf(format string, v ...interface{}) { Global.Fatalf(format, v...) }
 func Fatalln(v ...interface{})               { Global.Fatalln(v...) }
 
+func FinestEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	Global.FinestEx(extra, arg0, args...)
+}
+func FineEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	Global.FineEx(extra, arg0, args...)
+}
+func DebugEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	Global.DebugEx(extra, arg0, args...)
+}
+func TraceEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	Global.TraceEx(extra, arg0, args...)
+}
+func InfoEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	Global.InfoEx(extra, arg0, args...)
+}
+func WarnEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
+	return Global.WarnEx(extra, arg0, args...)
+}
+func ErrorEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
+	return Global.ErrorEx(extra, arg0, args...)
+}
+func CriticalEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
+	return Global.CriticalEx(extra, arg0, args...)
+}
+func LogEx(extra map[string]string, lvl Level, arg0 interface{}, args ...interface{}) {
+	Global.LogEx(extra, lvl, arg0, args...)
+}
+
 func AddLogger(logger ConfigLogger) int { return Global.AddLogger(logger) }
 func Close()                            { Global.Close() }
 

--- a/timber.go
+++ b/timber.go
@@ -6,79 +6,91 @@
 // quickly.  It's also easy to configure in code if you want to DIY.
 //
 // Basic use:
-//   import "timber"
-//   timber.LoadConfiguration("timber.xml")
-//   timber.Debug("Debug message!")
+//
+//	import "timber"
+//	timber.LoadConfiguration("timber.xml")
+//	timber.Debug("Debug message!")
 //
 // IMPORTANT: timber has not default destination configured so log messages
 // will be dropped until a destination is configured
 //
 // It can be used as a drop-in replacement for the standard logger
 // by changing the log import statement from:
-//   import "log"
+//
+//	import "log"
+//
 // to
-//   import log "timber"
+//
+//	import log "timber"
 //
 // It can also be used as the output of the standard logger with
-//   log.SetFlags(0)
-//   log.SetOutput(timber.Global)
+//
+//	log.SetFlags(0)
+//	log.SetOutput(timber.Global)
 //
 // Configuration in code is also simple:
-//		timber.AddLogger(timber.ConfigLogger{
-//			LogWriter: new(timber.ConsoleWriter),
-//			Level:     timber.DEBUG,
-//			Formatter: timber.NewPatFormatter("[%D %T] [%L] %S %M"),
-//		})
+//
+//	timber.AddLogger(timber.ConfigLogger{
+//		LogWriter: new(timber.ConsoleWriter),
+//		Level:     timber.DEBUG,
+//		Formatter: timber.NewPatFormatter("[%D %T] [%L] %S %M"),
+//	})
 //
 // XML Config file:
-//		<logging>
-//		  <filter enabled="true">
-//			<tag>stdout</tag>
-//			<type>console</type>
-//			<!-- level is (:?FINEST|FINE|DEBUG|TRACE|INFO|WARNING|ERROR) -->
-//			<level>DEBUG</level>
-//		  </filter>
-//		  <filter enabled="true">
-//			<tag>file</tag>
-//			<type>file</type>
-//			<level>FINEST</level>
-//			<granular>
-//			  <level>INFO</level>
-//			  <path>path/to/package.FunctionName</path>
-//			</granular>
-//			<granular>
-//			  <level>WARNING</level>
-//			  <path>path/to/package</path>
-//			</granular>
-//			<property name="filename">log/server.log</property>
-//			<property name="format">server [%D %T] [%L] %M</property>
-//		  </filter>
-//		  <filter enabled="false">
-//			<tag>syslog</tag>
-//			<type>socket</type>
-//			<level>FINEST</level>
-//			<property name="protocol">unixgram</property>
-//			<property name="endpoint">/dev/log</property>
-//		    <format name="pattern">%L %M</property>
-//		  </filter>
-//		</logging>
+//
+//	<logging>
+//	  <filter enabled="true">
+//		<tag>stdout</tag>
+//		<type>console</type>
+//		<!-- level is (:?FINEST|FINE|DEBUG|TRACE|INFO|WARNING|ERROR) -->
+//		<level>DEBUG</level>
+//	  </filter>
+//	  <filter enabled="true">
+//		<tag>file</tag>
+//		<type>file</type>
+//		<level>FINEST</level>
+//		<granular>
+//		  <level>INFO</level>
+//		  <path>path/to/package.FunctionName</path>
+//		</granular>
+//		<granular>
+//		  <level>WARNING</level>
+//		  <path>path/to/package</path>
+//		</granular>
+//		<property name="filename">log/server.log</property>
+//		<property name="format">server [%D %T] [%L] %M</property>
+//	  </filter>
+//	  <filter enabled="false">
+//		<tag>syslog</tag>
+//		<type>socket</type>
+//		<level>FINEST</level>
+//		<property name="protocol">unixgram</property>
+//		<property name="endpoint">/dev/log</property>
+//	    <format name="pattern">%L %M</property>
+//	  </filter>
+//	</logging>
+//
 // The <tag> is ignored.
 //
 // To configure the pattern formatter all filters accept:
-//		<format name="pattern">[%D %T] %L %M</format>
+//
+//	<format name="pattern">[%D %T] %L %M</format>
+//
 // Pattern format specifiers (not the same as log4go!):
-// 		%T - Time: 17:24:05.333 HH:MM:SS.ms
-// 		%t - Time: 17:24:05 HH:MM:SS
-// 		%D - Date: 2011-12-25 yyyy-mm-dd
-// 		%d - Date: 2011/12/25 yyyy/mm/dd
-// 		%L - Level (FNST, FINE, DEBG, TRAC, WARN, EROR, CRIT)
-// 		%S - Source: full runtime.Caller line and line number
-// 		%s - Short Source: just file and line number
-// 		%x - Extra Short Source: just file without .go suffix
-// 		%M - Message
-// 		%% - Percent sign
-// 		%P - Caller Path: packagePath.CallingFunctionName
-// 		%p - Caller Path: packagePath
+//
+//	%T - Time: 17:24:05.333 HH:MM:SS.ms
+//	%t - Time: 17:24:05 HH:MM:SS
+//	%D - Date: 2011-12-25 yyyy-mm-dd
+//	%d - Date: 2011/12/25 yyyy/mm/dd
+//	%L - Level (FNST, FINE, DEBG, TRAC, WARN, EROR, CRIT)
+//	%S - Source: full runtime.Caller line and line number
+//	%s - Short Source: just file and line number
+//	%x - Extra Short Source: just file without .go suffix
+//	%M - Message
+//	%% - Percent sign
+//	%P - Caller Path: packagePath.CallingFunctionName
+//	%p - Caller Path: packagePath
+//
 // the string number prefixes are allowed e.g.: %10s will pad the source field to 10 spaces
 // pattern defaults to %M
 // Both log4go synatax of <property name="format"> and new <format name=type> are supported
@@ -104,7 +116,6 @@
 // with log4go for the interface and configuration.  The main issue I had with log4go was that each of
 // logger types had incisistent and incompatible configuration.  I looked at contributing changes to
 // log4go, but I would have needed to break existing use cases so I decided to do a rewrite from scratch.
-//
 package timber
 
 import (
@@ -198,6 +209,17 @@ type Logger interface {
 	Errorf(arg0 interface{}, args ...interface{}) error
 	Criticalf(arg0 interface{}, args ...interface{}) error
 	Logf(lvl Level, arg0 interface{}, args ...interface{})
+
+	// allow passing of extra fields on the fly
+	FinestEx(extra map[string]string, arg0 interface{}, args ...interface{})
+	FineEx(extra map[string]string, arg0 interface{}, args ...interface{})
+	DebugEx(extra map[string]string, arg0 interface{}, args ...interface{})
+	TraceEx(extra map[string]string, arg0 interface{}, args ...interface{})
+	InfoEx(extra map[string]string, arg0 interface{}, args ...interface{})
+	WarnEx(extra map[string]string, arg0 interface{}, args ...interface{}) error
+	ErrorEx(extra map[string]string, arg0 interface{}, args ...interface{}) error
+	CriticalEx(extra map[string]string, arg0 interface{}, args ...interface{}) error
+	LogEx(extra map[string]string, lvl Level, arg0 interface{}, args ...interface{})
 }
 
 // Not used
@@ -230,6 +252,7 @@ type LogRecord struct {
 	MethodPath  string
 	PackagePath string
 	HostName    string
+	Extra       map[string]string `json:"extra,omitempty"`
 }
 
 // Format a log message before writing
@@ -303,7 +326,6 @@ type timberConfig struct {
 
 // Creates a new Timber logger that is ready to be configured
 // With no subsequent configuration, nothing will be logged
-//
 func NewTimber() *Timber {
 	t := new(Timber)
 	t.writerConfigChan = make(chan timberConfig)
@@ -436,14 +458,14 @@ func (t *Timber) SetFormatter(index int, formatter LogFormatter) {
 }
 
 // Logger interface
-func (t *Timber) prepareAndSend(lvl Level, msg string, depth int) {
+func (t *Timber) prepareAndSend(lvl Level, extra map[string]string, msg string, depth int) {
 	select {
 	case <-t.blackHole:
 		// the blackHole always blocks until we close
 		// then it always succeeds so we avoid writing
 		// to the closed channel
 	default:
-		t.recordChan <- t.prepare(lvl, msg, depth+1)
+		t.recordChan <- t.prepare(lvl, extra, msg, depth+1)
 	}
 }
 
@@ -474,7 +496,7 @@ func makeTimeLogglyCompat(t time.Time) time.Time {
 	return tLoggly
 }
 
-func (t *Timber) prepare(lvl Level, msg string, depth int) *LogRecord {
+func (t *Timber) prepare(lvl Level, extra map[string]string, msg string, depth int) *LogRecord {
 	now := makeTimeLogglyCompat(time.Now())
 	pc, file, line, _ := runtime.Caller(depth)
 	funcPath := "_"
@@ -500,8 +522,11 @@ func (t *Timber) prepare(lvl Level, msg string, depth int) *LogRecord {
 		MethodPath:  methodPath,
 		PackagePath: packagePath,
 		HostName:    hostname,
+		Extra:       extra,
 	}
 }
+
+var emptyExtra map[string]string
 
 // This function allows a Timber instance to be used in the standard library
 // log.SetOutput().  It is not a general Writer interface and assumes one
@@ -512,121 +537,155 @@ func (t *Timber) Write(p []byte) (n int, err error) {
 }
 
 func (t *Timber) Finest(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINEST, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(FINEST, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Fine(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(FINE, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Debug(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(DEBUG, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Trace(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(TRACE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(TRACE, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Info(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(INFO, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(INFO, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Warn(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(WARNING, msg, t.FileDepth)
+	t.prepareAndSend(WARNING, emptyExtra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Error(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(ERROR, msg, t.FileDepth)
+	t.prepareAndSend(ERROR, emptyExtra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Critical(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Log(lvl Level, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(lvl, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(lvl, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 
 // The govet printf family of warnings triggers on Erorr() and similar containing format strings
 // Add more golike Foof() formatters. Other methods should be considered deprecated
 func (t *Timber) Finestf(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINEST, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(FINEST, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Finef(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(FINE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(FINE, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Debugf(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(DEBUG, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Tracef(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(TRACE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(TRACE, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Infof(arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(INFO, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(INFO, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 func (t *Timber) Warnf(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(WARNING, msg, t.FileDepth)
+	t.prepareAndSend(WARNING, emptyExtra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Errorf(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(ERROR, msg, t.FileDepth)
+	t.prepareAndSend(ERROR, emptyExtra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Criticalf(arg0 interface{}, args ...interface{}) error {
 	msg := fmt.Sprintf(arg0.(string), args...)
-	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
 	return errors.New(msg)
 }
 func (t *Timber) Logf(lvl Level, arg0 interface{}, args ...interface{}) {
-	t.prepareAndSend(lvl, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+	t.prepareAndSend(lvl, emptyExtra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 
 // Print won't work well with a pattern_logger because it explicitly adds
 // its own \n; so you'd have to write your own formatter to remove it
 func (t *Timber) Print(v ...interface{}) {
-	t.prepareAndSend(DEBUG, fmt.Sprint(v...), t.FileDepth)
+	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprint(v...), t.FileDepth)
 }
 func (t *Timber) Printf(format string, v ...interface{}) {
-	t.prepareAndSend(DEBUG, fmt.Sprintf(format, v...), t.FileDepth)
+	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprintf(format, v...), t.FileDepth)
 }
 
 // Println won't work well either with a pattern_logger because it explicitly adds
 // its own \n; so you'd have to write your own formatter to not have 2 \n's
 func (t *Timber) Println(v ...interface{}) {
-	t.prepareAndSend(DEBUG, fmt.Sprintln(v...), t.FileDepth)
+	t.prepareAndSend(DEBUG, emptyExtra, fmt.Sprintln(v...), t.FileDepth)
 }
 func (t *Timber) Panic(v ...interface{}) {
 	msg := fmt.Sprint(v...)
-	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
 	panic(msg)
 }
 func (t *Timber) Panicf(format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
-	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
 	panic(msg)
 }
 func (t *Timber) Panicln(v ...interface{}) {
 	msg := fmt.Sprintln(v...)
-	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
 	panic(msg)
 }
 func (t *Timber) Fatal(v ...interface{}) {
 	msg := fmt.Sprint(v...)
-	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
 	t.Close()
 	os.Exit(1)
 }
 func (t *Timber) Fatalf(format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
-	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
 	t.Close()
 	os.Exit(1)
 }
 func (t *Timber) Fatalln(v ...interface{}) {
 	msg := fmt.Sprintln(v...)
-	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	t.prepareAndSend(CRITICAL, emptyExtra, msg, t.FileDepth)
 	t.Close()
 	os.Exit(1)
+}
+
+func (t *Timber) FinestEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(FINEST, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) FineEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(FINE, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) DebugEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(DEBUG, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) TraceEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(TRACE, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) InfoEx(extra map[string]string, arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(INFO, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) WarnEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
+	msg := fmt.Sprintf(arg0.(string), args...)
+	t.prepareAndSend(WARNING, extra, msg, t.FileDepth)
+	return errors.New(msg)
+}
+func (t *Timber) ErrorEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
+	msg := fmt.Sprintf(arg0.(string), args...)
+	t.prepareAndSend(ERROR, extra, msg, t.FileDepth)
+	return errors.New(msg)
+}
+func (t *Timber) CriticalEx(extra map[string]string, arg0 interface{}, args ...interface{}) error {
+	msg := fmt.Sprintf(arg0.(string), args...)
+	t.prepareAndSend(CRITICAL, extra, msg, t.FileDepth)
+	return errors.New(msg)
+}
+func (t *Timber) LogEx(extra map[string]string, lvl Level, arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(lvl, extra, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 
 //

--- a/timber.go
+++ b/timber.go
@@ -532,7 +532,7 @@ var emptyExtra map[string]string
 // log.SetOutput().  It is not a general Writer interface and assumes one
 // message per call to Write. All messages are send at level INFO
 func (t *Timber) Write(p []byte) (n int, err error) {
-	t.prepareAndSend(INFO, string(bytes.TrimSpace(p)), 4)
+	t.prepareAndSend(INFO, emptyExtra, string(bytes.TrimSpace(p)), 4)
 	return len(p), nil
 }
 

--- a/timber_test.go
+++ b/timber_test.go
@@ -1,7 +1,10 @@
 package timber
 
 import (
+	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConsole(t *testing.T) {
@@ -61,6 +64,75 @@ func TestDoubleClose(t *testing.T) {
 		Level:     DEBUG,
 		Formatter: formatter})
 	log.Close()
-	log.Close() // call Close twice	
+	log.Close() // call Close twice
 	log.Warn("Don't panic")
+}
+
+// writer to capture logs for testing purposes
+type TestWriter struct {
+	logs []string
+}
+
+func (tw *TestWriter) LogWrite(msg string) {
+	tw.logs = append(tw.logs, msg)
+}
+
+func (tw *TestWriter) Close() {
+	// Nothing
+}
+
+func TestJSONFormatterLogger(t *testing.T) {
+	a := assert.New(t)
+
+	log := NewTimber()
+	testWriter := new(TestWriter)
+	formatter := NewJSONFormatter()
+	log.AddLogger(
+		ConfigLogger{
+			LogWriter: testWriter,
+			Level:     DEBUG,
+			Formatter: formatter,
+		},
+	)
+	log.Info("Some JSON logging")
+	log.InfoEx(
+		map[string]string{
+			"testExtra":        "hello",
+			"testAnotherExtra": "goodbye",
+		},
+		"Some JSON logging with some extra fields",
+	)
+	log.Close()
+
+	firstLog := testWriter.logs[0]
+	secondLog := testWriter.logs[1]
+
+	var firstLogMap map[string]interface{}
+	var secondLogMap map[string]interface{}
+
+	json.Unmarshal([]byte(firstLog), &firstLogMap)
+	json.Unmarshal([]byte(secondLog), &secondLogMap)
+
+	expectedSharedKeys := []string{"Level", "timestamp", "SourceFile", "SourceFile", "message", "FuncPath", "FuncPath", "PackagePath", "HostName"}
+
+	// just check for presence of keys, as things like timestamp, hostname etc dependent on environment
+	for _, k := range expectedSharedKeys {
+		_, ok := firstLogMap[k]
+		a.True(ok)
+		_, ok = secondLogMap[k]
+		a.True(ok)
+	}
+
+	// first log should have expected message, and no "extra"
+	a.Equal(firstLogMap["message"], "Some JSON logging")
+	_, ok := firstLogMap["extra"]
+	a.False(ok)
+
+	// second log should have message, and "extra" fields
+	a.Equal(secondLogMap["message"], "Some JSON logging with some extra fields")
+	extra, ok := secondLogMap["extra"]
+	a.True(ok)
+	mapExtra := extra.(map[string]interface{})
+	a.Equal(mapExtra["testExtra"], "hello")
+	a.Equal(mapExtra["testAnotherExtra"], "goodbye")
 }

--- a/timber_test.go
+++ b/timber_test.go
@@ -113,7 +113,7 @@ func TestJSONFormatterLogger(t *testing.T) {
 	json.Unmarshal([]byte(firstLog), &firstLogMap)
 	json.Unmarshal([]byte(secondLog), &secondLogMap)
 
-	expectedSharedKeys := []string{"Level", "timestamp", "SourceFile", "SourceFile", "message", "FuncPath", "FuncPath", "PackagePath", "HostName"}
+	expectedSharedKeys := []string{"Level", "timestamp", "SourceFile", "SourceLine", "message", "FuncPath", "MethodPath", "PackagePath", "HostName"}
 
 	// just check for presence of keys, as things like timestamp, hostname etc dependent on environment
 	for _, k := range expectedSharedKeys {


### PR DESCRIPTION
The intention of this PR is to allow for the ability to provide an `extra` object to the timber logging interface, which, when using the JSONFormatter for logs, will allow these extra fields to be included in the JSON payload.

The motivation behind this PR is so that we can add extra JSON fields to individual log messages on the fly, in a similar manner to the "extra" functionality support in Python logging.

In the context of ecobee - this specifically addresses the ask on this [ticket](https://ecobee.atlassian.net/browse/CAMSERV-120?focusedCommentId=257466). 

Proposal here is that I've added a set of `<loglevel>Ex` functions that one can call on `timber`, that expects an `extra` argument alongside the regular string & variable substitution args, e.g:
```
timber.InfoEx(
  map[string]string{
    "someNewKeyAddedOnTheFly": "i_am_some_data",
  },
  "I am the log message",
)
```

For the regular/existing timber functions (i.e. `Info()` etc) - the extra field is ignored/not present due to the `omitempty`.

This PR also includes some minor formatting changes (autoformatted by VS code), the addition of a `go.mod` file so that I could run `go test github.com/cocoonlife/timber` to run the tests, and the addition of a relatively simple unit test to capture the new expected behaviour.