### PR TITLE
CAMSERV-120 - Fix depth, to align with prepare and send refactor

### DIFF
--- a/timber.go
+++ b/timber.go
@@ -474,7 +474,7 @@ func (t *Timber) doPrepareAndSend(lvl Level, extra map[string]string, msg string
 		// then it always succeeds so we avoid writing
 		// to the closed channel
 	default:
-		t.recordChan <- t.prepare(lvl, extra, msg, depth+2) // +2 required due to include the prepareAndSend function(s)
+		t.recordChan <- t.prepare(lvl, extra, msg, depth+2) // +2 required to accommodate the prepareAndSend function(s) in the call stack
 	}
 }
 

--- a/timber.go
+++ b/timber.go
@@ -474,7 +474,7 @@ func (t *Timber) doPrepareAndSend(lvl Level, extra map[string]string, msg string
 		// then it always succeeds so we avoid writing
 		// to the closed channel
 	default:
-		t.recordChan <- t.prepare(lvl, extra, msg, depth+1)
+		t.recordChan <- t.prepare(lvl, extra, msg, depth+2) // +2 required due to include the prepareAndSend function(s)
 	}
 }
 


### PR DESCRIPTION
This was an accidental miss from the last commit in https://github.com/cocoonlife/timber/pull/1 - given the refactor to split out prepareAndSendEx and prepareAndSend methods, we added another layer of functions - which means that we need to add +2 to the provided "file depth" instead of the previous +1 to account for this.

Without this, I notice that parent applications of timber show things like PackagePath, SourceFile, SourceLine etc at the level below that which they should (i.e. give the information relating to the exported "Info" etc functions within timber).

I have now tested this by importing from this branch (something I should have done before and been less over-confident about before 😅), and confirm that this fixes back to the expected behaviour.